### PR TITLE
Update bundle save path for TM 2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Installation
 
-- Clone the git repo to  `~/Library/Application Support/Avian/Bundles/Strip-Whitespace-On-Save.tmbundle`
+- Clone the git repo to `~/Library/Application\ Support/TextMate/Bundles/Strip-Whitespace-On-Save.tmbundle`
 - Relaunch TextMate 2
 
 


### PR DESCRIPTION
Update README to use the new bundle save path that TextMate 2 prefers.